### PR TITLE
fix: exclude .formatted date strategy case on Linux

### DIFF
--- a/Sources/ReerJSON/JSONDecoderImpl.swift
+++ b/Sources/ReerJSON/JSONDecoderImpl.swift
@@ -267,6 +267,7 @@ final class JSONDecoderImpl: Decoder {
                 ))
             }
             return date
+        #if !os(Linux)
         case .formatted(let formatter):
             let string = try unboxString(from: value, for: codingPathNode, additionalKey)
             guard let date = formatter.date(from: string) else {
@@ -276,6 +277,7 @@ final class JSONDecoderImpl: Decoder {
                 ))
             }
             return date
+        #endif
         case .custom(let closure):
             return try with(value: value, path: codingPathNode.appending(additionalKey)) {
                 try closure(self)

--- a/Sources/ReerJSON/JSONEncoderImpl.swift
+++ b/Sources/ReerJSON/JSONEncoderImpl.swift
@@ -283,8 +283,10 @@ class JSONEncoderImpl: Encoder {
             return try wrapFloat(1000.0 * date.timeIntervalSince1970, for: additionalKey)
         case .iso8601:
             return wrapString(_iso8601Formatter.string(from: date))
+        #if !os(Linux)
         case .formatted(let formatter):
             return wrapString(formatter.string(from: date))
+        #endif
         case .custom(let closure):
             return try _encodeNestedValue(for: additionalKey) { try closure(date, self) } ?? yyjson_mut_obj(doc)
         @unknown default: fatalError()


### PR DESCRIPTION
## Summary
- On Linux, `swift-foundation` (FoundationEssentials) does not define `.formatted` as an enum case on `DateEncodingStrategy` / `DateDecodingStrategy`. It is guarded by `#if FOUNDATION_FRAMEWORK` and only exists on Apple platforms.
- `swift-corelibs-foundation` provides a `static func formatted(_ formatter:)` that returns `.custom(...)` as a compatibility shim, so the `.custom` case already handles it at runtime.
- Wrap the `.formatted(let formatter)` switch cases with `#if !os(Linux)` in both `JSONDecoderImpl.swift` and `JSONEncoderImpl.swift`.

Closes #7

## Test plan
- [x] Verify compilation on Linux (Swift 6.x)
- [x] Verify existing tests still pass on macOS

Made with [Cursor](https://cursor.com)